### PR TITLE
Snapcraft

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ You can install Seashells from
 
     pip install seashells
 
+Seashells is also available as a snap package, installable on `supported
+<https://snapcraft.io/docs/core/install>`__ systems. These packages are
+securely confined and automatically updated.
+
+.. code:: bash
+
+    snap install seashells
+
 Usage
 -----
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: seashells
+version: git
+summary: The official client for Seashells.io
+description: |
+  Seashells lets you pipe output from command-line programs to the web in
+  real-time, even without installing any new software on your machine. You
+  can use it to monitor long-running processes like experiments that print
+  progress to the console. You can also use Seashells to share output with
+  friends!
+
+grade: stable
+confinement: strict
+
+apps:
+  seashells:
+    command: seashells
+    plugs: [network]
+
+parts:
+  seashells:
+    plugin: python
+    source: .


### PR DESCRIPTION
This adds a snap (https://snapcraft.io) for seashells, which enables easy automatic updates on Linux systems.

I've pushed a build to the store, so the instructions already work. If you'd like, I can transfer the `seashells` name over to you. You could then set up [auto-builds on git push](https://build.snapcraft.io) which auto-publish to the [edge channel](https://snapcraft.io/docs/reference/channels).